### PR TITLE
Updating index.js to account for nested add-ons

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,23 @@
 module.exports = {
   name: 'ember-truncate',
   included: function(app) {
+    var app,
+      current = this;
+
+    // If the addon has the _findHost() method (in ember-cli >= 2.7.0), we'll just
+    // use that.
+    if (typeof this._findHost === 'function') {
+      app = this._findHost();
+    }
+
+    // Otherwise, we'll use this implementation borrowed from the _findHost()
+    // method in ember-cli.
+    // Keep iterating upward until we don't have a grandparent.
+    // Has to do this grandparent check because at some point we hit the project.
+    do {
+      app = current.app || app;
+    } while (current.parent.parent && (current = current.parent));
+
     app.import('vendor/styles/truncate-multiline.css');
   }
 };


### PR DESCRIPTION
See https://github.com/ember-cli/ember-cli/issues/5747. When add-ons are nested more than two layers deep, app.import will not work.